### PR TITLE
Mise en prod v0 7 8 validata UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 footer:
   links:
     - title: Codes sources
-      url: https://git.opendatafrance.net/validata
+      url: https://gitlab.com/validata-table
 header:
   links:
     - title: Mode d'emploi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ./
     container_name: validata_$ENV_NAME
     environment:
-      - BADGE_CONFIG_URL=https://git.opendatafrance.net/validata/validata-badge/raw/master/badge_conf.toml
+      - BADGE_CONFIG_URL=https://gitlab.com/validata-table/validata-badge/raw/master/badge_conf.toml
       - CONFIG=config.yaml
       - CONFIG_FILE=config.yaml
       - HOMEPAGE_CONFIG_FILE=homepage_config.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 jinja2==3.0.3
-pydantic==1.10.9
-validata-ui==0.7.4
-opening-hours-py==0.5.6
+validata-ui==0.7.8


### PR DESCRIPTION
Le but de cette PR est d'intégrer les changements suivants :
- Les travaux réalisés concernant la redirection d'url (inclus dans la version v0.7.7 de validata-ui déjà déployée en preprod)
- Les correction de bugs sur les requirements concernant les packages `open-hours-py` et `pydantic` (inclus dans la version v0.7.7 de validata-ui déjà déployée en preprod)
- La modification du fichier `requirements.txt` pour : 
    -  Prendre en compte la montée de version du package validata-ui vers la version [v0.7.8](https://gitlab.com/validata-table/validata-ui/-/commit/55d4fd4f3667085da47f2e826306ea403dfa9865)
    - Supprimer les versions des packages `open-hours-py` et `pydantic` (pour être cohérent avec la correction de bug apportée par la version v0.7.7 du package de validata-ui)
- La modification de fichiers de configuration pour prendre en compte la migration actuellement en cours des projets de Validata Table initialement hébergés sur une instance gitlab privée d'ODF (https://git.opendatafrance.net/validata) vers la nouvelle instance publique [gitlab.com/Validata-Table](https://gitlab.com/validata-table) : 
    -  Modification du fichier `config.yaml` pour modifier l'url du footer pour la faire pointer vers l'instance [gitlab.com/Validata-Table](https://gitlab.com/validata-table)
    - Modification de la variable d'environnement `BADGE_CONFIG_URL` dans le fichier `docker-compose.yaml` pour la faire pointer vers le fichier hébergé dans la nouvelle instance de [gitlab.com/Validata-Table]