### PR TITLE
Mise en preprod v0.7.9 validata UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jinja2==3.0.3
-validata-ui==0.7.8
+validata-ui==0.7.9


### PR DESCRIPTION
Ce commit a pour but de passer [à la version v0.7.9 de validata-ui](https://gitlab.com/validata-table/validata-ui/-/commit/d1c9f6aba1a5dcdc129acf56a0e901c0efafb4d7)

Cette montée de version intègre : 
- le rajout d'une checkbox dans Validata.fr pour permettre à l'utilisateur.rice le choix de la sensitivité à la casse dnas les en-têtes de colonnes
- de modifier les urls des schémas qui pointaient vers l'instance gitlab privée d'Opendatafrance vers une instance gitlab.com publique
- de corriger le lien pour "Signaler un problème" pour créer une nouvelle issue dnas le dépôt giitlab de validata-ui