### PR TITLE
Edit requirements.txt to use the new package validata-table v0.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-jinja2==3.0.3
-validata-ui==0.7.9
+validata-table==0.10.1


### PR DESCRIPTION
This pull request aims to use the new package `validata-table` resulting from the migration of Validata Table project into the [new gitlab mono-repository validata-table](https://gitlab.com/validata-table/validata-table)

It will need to update locally .env file to set FLASK_SECRET_KEY environment variable before deploy in preprod.